### PR TITLE
Add new developer resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Read the [contribution guidelines](CONTRIBUTING.md) before submitting a resource
 
 ### Developers
 * Official [HASH developer site](https://hash.dev/?utm_medium=organic&utm_source=github_readme_awesomehash-repo_root)
+    * Official [developer blog](https://hash.dev/blog?utm_medium=organic&utm_source=github_readme_awesomehash-repo_root)
+    * Official [developer docs](https://hash.dev/docs?utm_medium=organic&utm_source=github_readme_awesomehash-repo_root)
+    * Official [development roadmap](https://hash.dev/roadmap?utm_medium=organic&utm_source=github_readme_awesomehash-repo_root)
 
 ## Community
 * Official [HASH Discord](https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_awesomehash-repo_root)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Read the [contribution guidelines](CONTRIBUTING.md) before submitting a resource
 ## Resources
 
 ### User Guides & Tutorials
-* Official [HASH user guide](https://hash.ai/docs?utm_medium=organic&utm_source=github_readme_awesomehash-repo_root)
-* Official guide to [using HASH for simulation](https://hash.ai/docs/simulation?utm_medium=organic&utm_source=github_readme_awesomehash-repo_root)
+* Official [HASH user guide](https://hash.ai/guide?utm_medium=organic&utm_source=github_readme_awesomehash-repo_root)
+* Official guide to [using HASH for simulation](https://hash.ai/guide/simulation?utm_medium=organic&utm_source=github_readme_awesomehash-repo_root)
 
 ### Developers
 * Official [HASH developer site](https://hash.dev/?utm_medium=organic&utm_source=github_readme_awesomehash-repo_root)


### PR DESCRIPTION
The `hash.dev/docs` developer docs and `hash.ai/guide` user guide are not live yet, so we should wait for them to go in before merging this.

Blocked by https://github.com/hashintel/hash/pull/2069 and https://github.com/hashintel/hash/pull/2768