### PR TITLE
Add links to project's source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A curated list of the best resources in the HASH ecosystem.
 
-[HASH](https://github.com/hashintel/hash) is a powerful platform for knowledge management and decision-making. With it you can integrate and structure data, build block-based interfaces, and develop simulation models of your world.
+[HASH](https://github.com/hashintel/hash) is a powerful platform for knowledge management and decision-making. With it you can integrate and structure data, build interfaces on top of it, and develop models of your world.
 
 Read the [contribution guidelines](CONTRIBUTING.md) before submitting a resource. Please also note that this repository is *new* and will be expanded in due course.
 
@@ -11,6 +11,9 @@ Read the [contribution guidelines](CONTRIBUTING.md) before submitting a resource
 * [Resources](#resources)
     * [User Guides & Tutorials](#user-guides--tutorials)
     * [Developers](#developers)
+* [Source Code](#source-code)
+    * [Active Projects](#active-projects)
+    * [Experiments](#experiments)
 * [Community](#community)
 
 ## Resources
@@ -21,6 +24,17 @@ Read the [contribution guidelines](CONTRIBUTING.md) before submitting a resource
 
 ### Developers
 * Official [HASH developer site](https://hash.dev/?utm_medium=organic&utm_source=github_readme_awesomehash-repo_root)
+
+## Source Code
+
+### Active Projects
+* [HASH](https://github.com/hashintel/hash)
+
+### Experiments
+* [HASH Engine](https://github.com/hashintel/labs/tree/main/apps/sim-engine) (hEngine): 
+* [HASH Core](https://github.com/hashintel/labs/tree/main/apps/sim-core) (hCore)
+* [HASH Core Plugins](https://github.com/hashintel/labs/tree/main/apps/sim-engine-plugins)
+* [Other proof of concepts](https://github.com/hashintel/labs/tree/main/pocs)
 
 ## Community
 * Official [HASH Discord](https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_awesomehash-repo_root)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Read the [contribution guidelines](CONTRIBUTING.md) before submitting a resource
 * [HASH](https://github.com/hashintel/hash)
 
 ### Experiments
-* [HASH Engine](https://github.com/hashintel/labs/tree/main/apps/sim-engine) (hEngine): 
+* [HASH Engine](https://github.com/hashintel/labs/tree/main/apps/sim-engine) (hEngine)
 * [HASH Core](https://github.com/hashintel/labs/tree/main/apps/sim-core) (hCore)
 * [HASH Core Plugins](https://github.com/hashintel/labs/tree/main/apps/sim-engine-plugins)
 * [Other proof of concepts](https://github.com/hashintel/labs/tree/main/pocs)


### PR DESCRIPTION
Now hEngine has been spun out into the `labs` folder we want to improve sign-posting for it.